### PR TITLE
FIX: Uers that can view an object can also access the workflow log for that object.

### DIFF
--- a/code/dataobjects/WorkflowInstance.php
+++ b/code/dataobjects/WorkflowInstance.php
@@ -362,7 +362,10 @@ class WorkflowInstance extends DataObject {
 
 		// This method primarily "protects" access to a WorkflowInstance, but assumes access only to be granted to users assigned-to that WorkflowInstance.
 		// However; lowly authors (users entering items into a workflow) are not assigned - but we still wish them to see their submitted content.
-		$inWorkflowGroupOrUserTables = ($member->inGroups($this->Groups()) || $this->Users()->find('ID', $member->ID));
+		$inWorkflowGroupOrUserTables = ($member->inGroups($this->Groups()) 
+			|| $this->Users()->find('ID', $member->ID))
+			|| ($this->Target()->canView($member) && Permission::check('CMS_ACCESS_CMSMain'));
+
 		// This method is used in more than just the ModelAdmin. Check for the current controller to determine where canView() expectations differ
 		if(Controller::curr()->getAction() == 'index' && !$inWorkflowGroupOrUserTables) {
 			if($this->getVersionedConnection($this->getTarget()->ID,$member->ID,$this->DefinitionID)) {

--- a/code/dataobjects/WorkflowInstance.php
+++ b/code/dataobjects/WorkflowInstance.php
@@ -364,7 +364,7 @@ class WorkflowInstance extends DataObject {
 		// However; lowly authors (users entering items into a workflow) are not assigned - but we still wish them to see their submitted content.
 		$inWorkflowGroupOrUserTables = ($member->inGroups($this->Groups()) 
 			|| $this->Users()->find('ID', $member->ID))
-			|| ($this->Target()->canView($member) && Permission::check('CMS_ACCESS_CMSMain'));
+			|| ($this->Target()->canView($member) && Permission::check('CMS_ACCESS_CMSMain') && $this->WorkflowStatus == 'Complete');
 
 		// This method is used in more than just the ModelAdmin. Check for the current controller to determine where canView() expectations differ
 		if(Controller::curr()->getAction() == 'index' && !$inWorkflowGroupOrUserTables) {


### PR DESCRIPTION
So that content authors can view the workflow log for pages that they have access to.
