### PR TITLE
NEW/API Multiple workflows attached to one object

### DIFF
--- a/code/controllers/FrontEndWorkflowController.php
+++ b/code/controllers/FrontEndWorkflowController.php
@@ -142,7 +142,7 @@ abstract class FrontEndWorkflowController extends Controller {
 			throw new Exception('Context Object Not Found');
 		}
 
-		if(!$this->getCurrentTransition()->canExecute($this->contextObj->getWorkflowInstance())){
+		if(!$this->getCurrentTransition()->canExecute($this->contextObj->getWorkflowInstances())){
 			throw new Exception('You do not have permission to execute this action');
 		}
 		
@@ -156,15 +156,15 @@ abstract class FrontEndWorkflowController extends Controller {
 		}
 		
 		//run execute on WorkflowInstance instance		
-		$action = $this->contextObj->getWorkflowInstance()->currentAction();
-		$action->BaseAction()->execute($this->contextObj->getWorkflowInstance());
+		$action = $this->contextObj->getWorkflowInstances()->currentAction();
+		$action->BaseAction()->execute($this->contextObj->getWorkflowInstances());
 		
 		//get valid transitions
 		$transitions = $action->getValidTransitions();
 		
 		//tell instance to execute transition if it's in the permitted list
 		if ($transitions->find('ID',$this->transitionID)) {
-			$this->contextObj->getWorkflowInstance()->performTransition($this->getCurrentTransition());
+			$this->contextObj->getWorkflowInstances()->performTransition($this->getCurrentTransition());
 		}
 	}	
 
@@ -175,7 +175,7 @@ abstract class FrontEndWorkflowController extends Controller {
 	public function Title(){
 		if (!$this->Title) {
 			if($this->getContextObject()){
-				if($workflow = $this->contextObj->getWorkflowInstance()){
+				if($workflow = $this->contextObj->getWorkflowInstances()){
 					$this->Title = $workflow->currentAction()->BaseAction()->PageTitle ? $workflow->currentAction()->BaseAction()->PageTitle : $workflow->currentAction()->Title;	
 				}
 			}

--- a/code/dataobjects/WorkflowActionInstance.php
+++ b/code/dataobjects/WorkflowActionInstance.php
@@ -42,7 +42,7 @@ class WorkflowActionInstance extends DataObject {
 	 */
 	public function updateWorkflowFields($fields) {
 		if ($this->BaseAction()->AllowCommenting) {	
-			$fields->push(new TextareaField('Comment', _t('WorkflowAction.COMMENT', 'Comment')));
+			$fields->push(new TextareaField('Comment[' . $this->WorkflowID . ']', _t('WorkflowAction.COMMENT', 'Comment')));
 		}
 	}
 	

--- a/code/dataobjects/WorkflowDefinition.php
+++ b/code/dataobjects/WorkflowDefinition.php
@@ -31,6 +31,14 @@ class WorkflowDefinition extends DataObject {
 		'Actions'   => 'WorkflowAction',
 		'Instances' => 'WorkflowInstance'
 	);
+	
+	/**
+	 *
+	 * @var array
+	 */
+	public static $belongs_many_many = array(
+		'WorkflowApplicable' => 'DataObject'
+	);
 
 	/**
 	 * By default, a workflow definition is bound to a particular set of users or groups.

--- a/code/dataobjects/WorkflowInstance.php
+++ b/code/dataobjects/WorkflowInstance.php
@@ -121,7 +121,7 @@ class WorkflowInstance extends DataObject {
 	public function updateWorkflow($data) {
 		$action = $this->CurrentAction();
 
-		if (!$this->getTarget() || !$this->getTarget()->canEditWorkflow()) {
+		if(!$this->getTarget() || !$this->getTarget()->canEditWorkflow($this)) {
 			return;
 		}
 
@@ -171,7 +171,7 @@ class WorkflowInstance extends DataObject {
 	 * @param WorkflowDefinition $definition
 	 * @param DataObject $for
 	 */
-	public function beginWorkflow(WorkflowDefinition $definition, DataObject $for=null) {
+	public function beginWorkflow(WorkflowDefinition $definition, DataObject $for = null) {
 		if(!$this->ID) {
 			$this->write();
 		}
@@ -424,13 +424,13 @@ class WorkflowInstance extends DataObject {
 	 * @return FieldList
 	 */
 	public function getWorkflowFields() {
-		$action    = $this->CurrentAction();
+		$action = $this->CurrentAction();
 		$options   = $this->validTransitions();
 		$wfOptions = $options->map('ID', 'Title', ' ');
 		$fields    = new FieldList();
 
-		$fields->push(new HeaderField('WorkflowHeader', $action->Title));
-		$fields->push(new DropdownField('TransitionID', _t('WorkflowInstance.NEXT_ACTION', 'Next Action'), $wfOptions));
+		$fields->push(new HeaderField('WorkflowHeader[' . $this->ID . ']', $action->Title));
+		$fields->push(new DropdownField('TransitionID[' . $this->ID . ']', _t('WorkflowInstance.NEXT_ACTION', 'Next Action'), $wfOptions));
 
 		// Let the Active Action update the fields that the user can interact with so that data can be
 		// stored for the workflow.

--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -261,8 +261,8 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 	 */
 	public function setIsWorkflowInEffect() {
 		// if there is a workflow applied, we can't set the publishing date directly, only the 'desired' publishing date
-		$effective = $this->workflowService->getDefinitionFor($this->owner);
-		$this->isWorkflowInEffect = $effective?true:false;
+		$definitions = $this->workflowService->getDefinitionsFor($this->owner);
+		$this->isWorkflowInEffect = $definitions->count() ? true : false;
 	}
 
 	public function getIsWorkflowInEffect() {


### PR DESCRIPTION
This changes the relation from a WorkflowApplicable to 
WorkflowDefinition from has_one to many_many. This means that any call
to getDefinitionFor() and getWorkflowFor() now returns a SS_List that
will be needed to iterated through.

There were some tweaks to the AdvancedWorkflowExtension to support
Comments and Actions per workflow. So that commenting / starting /
updating a workflow leaves any other workflows alone.

The weakest point is around file-based workflows and permissions, I've
tested it for several hours. But since there are no tests or
documentation on how the permissions should work, I can't tell if it
still works as intended.
