### PR TITLE
API Remove restricted users from the workflow definition

### DIFF
--- a/code/admin/WorkflowDefinitionExporter.php
+++ b/code/admin/WorkflowDefinitionExporter.php
@@ -70,8 +70,6 @@ class WorkflowDefinitionExporter {
 		$templateData = new ArrayData(array(
 			'ExportMetaData' => $this->ExportMetaData(),
 			'ExportActions' => $def->Actions(),
-			'ExportUsers' => $def->Users(),
-			'ExportGroups' => $def->Groups() 
 		));
 		return $this->format($templateData);
 	}

--- a/code/dataobjects/WorkflowDefinition.php
+++ b/code/dataobjects/WorkflowDefinition.php
@@ -32,19 +32,6 @@ class WorkflowDefinition extends DataObject {
 		'Instances' => 'WorkflowInstance'
 	);
 
-	/**
-	 * By default, a workflow definition is bound to a particular set of users or groups.
-	 *
-	 * This is covered across to the workflow instance - it is up to subsequent
-	 * workflow actions to change this if needbe.
-	 *
-	 * @var array
-	 */
-	public static $many_many = array(
-		'Users' => 'Member',
-		'Groups' => 'Group'
-	);
-
 	public static $icon = 'advancedworkflow/images/definition.png';
 
 	public static $default_workflow_title_base = 'My Workflow';
@@ -126,8 +113,6 @@ class WorkflowDefinition extends DataObject {
 	 * @return void
 	 */
 	private function removeRelatedHasLists() {
-		$this->Users()->removeAll();
-		$this->Groups()->removeAll();
 		$this->Actions()->each(function($action) {
 			if($orphan = DataObject::get_by_id('WorkflowAction', $action->ID)) {
 				$orphan->delete();
@@ -170,12 +155,9 @@ class WorkflowDefinition extends DataObject {
 		
 		$fields = new FieldList(new TabSet('Root'));
 
+
 		$fields->addFieldToTab('Root.Main', new TextField('Title', $this->fieldLabel('Title')));
 		$fields->addFieldToTab('Root.Main', new TextareaField('Description', $this->fieldLabel('Description')));
-		if($this->ID) {
-			$fields->addFieldToTab('Root.Main', new CheckboxSetField('Users', _t('WorkflowDefinition.USERS', 'Users'), $cmsUsers));
-			$fields->addFieldToTab('Root.Main', new TreeMultiselectField('Groups', _t('WorkflowDefinition.GROUPS', 'Groups'), 'Group'));
-		}
 
 		if (class_exists('AbstractQueuedJob')) {
 			$before = _t('WorkflowDefinition.SENDREMINDERDAYSBEFORE', 'Send reminder email after ');

--- a/code/dataobjects/WorkflowInstance.php
+++ b/code/dataobjects/WorkflowInstance.php
@@ -224,9 +224,6 @@ class WorkflowInstance extends DataObject {
 		$this->CurrentActionID = $action->ID;
 		$this->InitiatorID     = Member::currentUserID();
 		$this->write();
-
-		$this->Users()->addMany($definition->Users());
-		$this->Groups()->addMany($definition->Groups());
 	}
 
 	/**

--- a/code/templates/WorkflowTemplate.php
+++ b/code/templates/WorkflowTemplate.php
@@ -140,14 +140,6 @@ class WorkflowTemplate {
 					$transitions->append($t);
 				}
 			}
-			// Process users on WorkflowDefinition from the template
-			if($isUsers) {
-				$this->createUsers($relationTemplate, $definition);
-			}
-			// Process groups on WorkflowDefinition from the template
-			if($isGroups) {
-				$this->createGroups($relationTemplate, $definition);
-			}			
 		}
 
 		foreach ($transitions as $transition) {
@@ -195,42 +187,6 @@ class WorkflowTemplate {
 		
 		return $action;
 	}
-	
-	/**
-	 * Create a WorkflowDefinition->Users relation based on template data. But only if the related groups from the
-	 * export, can be foud in the target environment's DB.
-	 * 
-	 * Note: The template gives us a Member Email to work with rather than an ID as it's arguably
-	 * more likely that Member Emails will be the same between environments than their IDs.
-	 * 
-	 * @param array $users
-	 * @param WorkflowDefinition $definition
-	 * @param boolean $clear
-	 * @return void
-	 */
-	protected function createUsers($users, WorkflowDefinition $definition, $clear = false) {
-		// Create the necessary relation in WorkflowDefinition_Users
-		$source = array('users' => $users);
-		$this->addManyManyToObject($definition, $source, $clear);
-	}
-	
-	/**
-	 * Create a WorkflowDefinition->Groups relation based on template data, But only if the related groups from the
-	 * export, can be foud in the target environment's DB.
-	 * 
-	 * Note: The template gives us a Group Title to work with rther than an ID as it's arguably
-	 * more likely that Group titles will be the same between environments than their IDs.
-	 * 
-	 * @param array $groups
-	 * @param WorkflowDefinition $definition
-	 * @param boolean $clear
-	 * @return void
-	 */
-	protected function createGroups($groups, WorkflowDefinition $definition, $clear = false) {
-		// Create the necessary relation in WorkflowDefinition_Groups
-		$source = array('groups' => $groups);
-		$this->addManyManyToObject($definition, $source, $clear);
-	}	
 	
 	/**
 	 * Update the transitions for a given action
@@ -308,9 +264,7 @@ class WorkflowTemplate {
 		foreach ($this->structure as $relationName => $relationTemplate) {
 			
 			$isAction = isset($relationTemplate['type']);
-			$isUsers = ($relationName == 'users');
-			$isGroups = ($relationName == 'groups');
-			
+
 			if($isAction) {
 				$action = null;
 				if (isset($existingActions[$relationName])) {
@@ -330,14 +284,6 @@ class WorkflowTemplate {
 					$transitions->append($t);
 				}
 			}
-			// Process users on WorkflowDefinition from the template
-			if($isUsers) {
-				$this->createUsers($relationTemplate, $definition, true);
-			}
-			// Process groups on WorkflowDefinition from the template
-			if($isGroups) {
-				$this->createGroups($relationTemplate, $definition, true);
-			}			
 		}
 		
 		foreach ($transitions as $transition) {

--- a/tests/WorkflowPermissionsTest.php
+++ b/tests/WorkflowPermissionsTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Tests for permissions on all Workflow Objects.
- * These will obviousely need to be modified should additional workflow permissions come online.
+ * These will obviously need to be modified should additional workflow permissions come online.
  *
  * @author     russell@silverstripe.com
  * @license    BSD License (http://silverstripe.org/bsd-license/)
@@ -85,6 +85,5 @@ class WorkflowPermissionsTest extends SapphireTest {
 		$this->assertTrue($workflowdef->Actions()->first()->Transitions()->first()->canCreate());
 		$this->assertTrue($workflowdef->Actions()->first()->Transitions()->first()->canEdit());
 		$this->assertTrue($workflowdef->Actions()->first()->Transitions()->first()->canDelete());	
-	}	
-
+	}
 }


### PR DESCRIPTION
The restricted users / groups on the workflow editing and creation page is regarded as obsolete and deprecated.
Users should be assigned to a workflow by using the "Assign Users To Workflow Action" action.
