### PR TITLE
Patch Add an extra ListingTemplate condition

### DIFF
--- a/code/actions/NotifyUsersWorkflowAction.php
+++ b/code/actions/NotifyUsersWorkflowAction.php
@@ -31,7 +31,7 @@ class NotifyUsersWorkflowAction extends WorkflowAction {
 				$this->fieldLabel('FormattingHelp'), new LiteralField('FormattingHelp', $this->getFormattingHelp()))
 		));
 
-		if (class_exists('ListingPage')) {
+		if (class_exists('ListingPage') && class_exists('ListingTemplate')) {
 			// allow the user to select an existing 'listing template'. The "getItems()" for that template
 			// will be the list of items in the workflow
 			$templates = DataObject::get('ListingTemplate');


### PR DESCRIPTION
I have my own implementation of a ListingPage and do not use the ListingTemplate/ListingPage module.
The extra condition ensures this logic if skipped if the ListingTemplate/ListingPage module is not being used but seperate ListingPage object has been defined.
