### PR TITLE
Feature type based workflow. Assign workflows to data objects

### DIFF
--- a/code/admin/AdvancedWorkflowAdmin.php
+++ b/code/admin/AdvancedWorkflowAdmin.php
@@ -25,7 +25,10 @@ class AdvancedWorkflowAdmin extends ModelAdmin {
 		'' => 'index'
 	);
 
-	private static $managed_models  = 'WorkflowDefinition';
+	private static $managed_models  = array(
+		'WorkflowDefinition',
+		'WorkflowTypeConfiguration'
+	);
 
 	private static $model_importers = array(
 		'WorkflowDefinition' => 'WorkflowBulkLoader'

--- a/code/dataobjects/WorkflowTypeConfiguration.php
+++ b/code/dataobjects/WorkflowTypeConfiguration.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Description of WorkflowTypeConfiguration
+ *
+ * @author Stephen McMahon <stephen@silverstripe.com.au>
+ */
+class WorkflowTypeConfiguration extends DataObject {
+	
+	private static $db = array(
+		'ControlledTypes' => 'MultiValueField'
+	);
+
+	private static $extensions = array(
+		'WorkflowApplicable' => 'WorkflowApplicable'
+	);
+	
+	public function getCMSFields() {
+		$fields = parent::getCMSFields();
+		
+		$classListField = MultiValueDropdownField::create(
+			'ControlledTypes',
+			'Controlled Types',
+			ClassInfo::subclassesFor('DataObject')
+		);
+		
+		$fields->replaceField('ControlledTypes', $classListField);
+		
+		return $fields;
+	}
+	
+}

--- a/code/extensions/TypeBasedWorkflowApplicable.php
+++ b/code/extensions/TypeBasedWorkflowApplicable.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Description of TypeBasedWorkflowApplicable
+ *
+ * @author Stephen McMahon <stephen@silverstripe.com.au>
+ */
+class TypeBasedWorkflowApplicable extends Extension {
+	
+	public function updateCMSFields(FieldList $fields) {
+		$fields->removeByName('WorkflowDefinitionID');
+		$fields->removeByName('AdditionalWorkflowDefinitions');
+	}
+	
+	/**
+	 * Looks for any WorkflowTypeConfiguration that applies to this Class or it's Ancestors
+	 * 
+	 * @return WorkflowTypeConfiguration|null
+	 */
+	public function workflowParent() {
+		
+		//DataObject::getClassAncestry returns with the current class as the last element so we flip it before we loop
+		$classAncestry = array_reverse($this->owner->getClassAncestry());
+		$wftc = null;
+		
+		foreach ($classAncestry as $className) {
+			$workflows = WorkflowTypeConfiguration::get()->filter('ControlledTypesValue:PartialMatch', $className);
+			if($workflows->count()) {
+				//@TODO add some logic or config here. If multiple Workflows matc which one do we use?
+				$wftc = $workflows->last();
+				break;
+			}
+		}
+		
+		return $wftc;
+	}
+}

--- a/code/extensions/WorkflowApplicable.php
+++ b/code/extensions/WorkflowApplicable.php
@@ -198,10 +198,14 @@ class WorkflowApplicable extends DataExtension {
 								$majorActions = $actions->fieldByName('MajorActions');
 								$majorActions ? $majorActions->push($action) : $actions->insertBefore($action, 'ActionMenus');
 							} else {
+								//Make sure $action renders as a <button> in ModelAdmin without this it renders as an
+								//<input>
+								$action->setUseButtonTag(true);
 								$tab->push($action);
 							}
 						}
 					}
+					//Add the AdditionalWorkflows tab 
 					$menu->push($tab);
 				}
 				

--- a/code/extensions/WorkflowApplicable.php
+++ b/code/extensions/WorkflowApplicable.php
@@ -182,7 +182,6 @@ class WorkflowApplicable extends DataExtension {
 					$tab = Tab::create(
 						'AdditionalWorkflows'
 					);
-					$menu->insertBefore($tab, 'MoreOptions');
 					$addedFirst = false;
 					foreach($definitions as $definition) {
 						if($definition->getInitialAction()) {
@@ -194,15 +193,16 @@ class WorkflowApplicable extends DataExtension {
 							// The first element is the main workflow definition, and will be displayed as a major action.
 
 							if(!$addedFirst) {
-								$addedFirst = true;
+								$addedFirst = $action->getName();
 								$action->setAttribute('data-icon', 'navigation');
 								$majorActions = $actions->fieldByName('MajorActions');
-								$majorActions ? $majorActions->push($action) : $actions->push($action);
+								$majorActions ? $majorActions->push($action) : $actions->insertBefore($action, 'ActionMenus');
 							} else {
 								$tab->push($action);
 							}
 						}
 					}
+					$menu->push($tab);
 				}
 				
 			}

--- a/code/services/WorkflowService.php
+++ b/code/services/WorkflowService.php
@@ -91,8 +91,8 @@ class WorkflowService implements PermissionProvider {
 	 */
 	public function getAdditionalDefinitionsFor(DataObject $dataObject) {
 		if ($dataObject->hasExtension('WorkflowApplicable') || $dataObject->hasExtension('FileWorkflowApplicable')) {
-			if ($dataObject->collectAdditionalWorkflowDefinitions()->count()) {
-				return $dataObject->collectAdditionalWorkflowDefinitions();
+			if ($dataObject->AdditionalWorkflowDefinitions()->count()) {
+				return $dataObject->AdditionalWorkflowDefinitions();
 			}
 			if ($dataObject->ParentID) {
 				return $this->getAdditionalDefinitionsFor($dataObject->Parent());

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
 	],
 	"require":
 	{
-		"silverstripe/cms": ">=3.0.0"
+		"silverstripe/cms": ">=3.0.0",
+		"silverstripe/multivaluefield": "~2.2"
 	},
 	"extra": {
 		"branch-alias": {


### PR DESCRIPTION
Outstanding issue:
Currently the `ControlledTypes` is a multivalue field list of class names, when doing the look up for matching class names of the current object we're doing:

``` php
$workflows = WorkflowTypeConfiguration::get()->filter('ControlledTypesValue:PartialMatch', $className);
```

This it likely to cause 'fun' when using basic or over lapping class names e.g with `Calendar` and `CalendarItem', the`Calendar' would collect the `CalendarItem` definitions even if it's not in the hierarchy.
