### PR TITLE
Cancel embargo expiry button

### DIFF
--- a/code/actions/PublishItemWorkflowAction.php
+++ b/code/actions/PublishItemWorkflowAction.php
@@ -14,6 +14,7 @@ class PublishItemWorkflowAction extends WorkflowAction {
 	private static $db = array(
 		'PublishDelay'          => 'Int',
         'AllowEmbargoedEditing' => 'Boolean',
+        'CanCancelEmbargoExpiry' => 'Boolean'
 	);
 
     private static $defaults = array(
@@ -35,6 +36,7 @@ class PublishItemWorkflowAction extends WorkflowAction {
             // disable editing, and embargo the delay if using WorkflowEmbargoExpiryExtension
             if ($target->hasExtension('WorkflowEmbargoExpiryExtension')) {
                 $target->AllowEmbargoedEditing = $this->AllowEmbargoedEditing;
+                $target->CanCancelEmbargoExpiry = $this->CanCancelEmbargoExpiry;
                 $target->PublishOnDate = $after;
                 $target->write();
             } else {
@@ -42,6 +44,7 @@ class PublishItemWorkflowAction extends WorkflowAction {
             }
 		} else if ($target->hasExtension('WorkflowEmbargoExpiryExtension')) {
             $target->AllowEmbargoedEditing = $this->AllowEmbargoedEditing;
+            $target->CanCancelEmbargoExpiry = $this->CanCancelEmbargoExpiry;
 			// setting future date stuff if needbe
 
 			// set this value regardless
@@ -73,9 +76,11 @@ class PublishItemWorkflowAction extends WorkflowAction {
 			$after  = _t('PublishItemWorkflowAction.DELAYPUBDAYSAFTER', ' days');
             $allowEmbargoed =  _t('PublishItemWorkflowAction.ALLOWEMBARGOEDEDITING',
                 'Allow editing while item is embargoed? (does not apply without embargo)');
+            $cancelLabel = _t('PublishItemWorkflowAction.CANCELEMBARGOEXPIRY', 'Allow cancelling embargo and expiry (if applicable)');
 
 			$fields->addFieldsToTab('Root.Main', array(
                 new CheckboxField('AllowEmbargoedEditing', $allowEmbargoed),
+                new CheckboxField('CanCancelEmbargoExpiry', $cancelLabel),
                 new FieldGroup(
                     _t('PublishItemWorkflowAction.PUBLICATIONDELAY', 'Publication Delay'),
                     new LabelField('PublishDelayBefore', $before),

--- a/code/dataobjects/WorkflowDefinition.php
+++ b/code/dataobjects/WorkflowDefinition.php
@@ -41,6 +41,9 @@ class WorkflowDefinition extends DataObject {
 	);
 
 	/**
+     * The users or groups defined in the workflow definition determines if they have permission to cancel an embargo
+     * and expiry if either is present.
+	 *
 	 * By default, a workflow definition is bound to a particular set of users or groups.
 	 *
 	 * This is covered across to the workflow instance - it is up to subsequent

--- a/code/extensions/AdvancedWorkflowExtension.php
+++ b/code/extensions/AdvancedWorkflowExtension.php
@@ -5,18 +5,64 @@ use SilverStripe\Security\Permission;
 
 /**
  * Handles interactions triggered by users in the backend of the CMS. Replicate this
- * type of functionality wherever you need UI interaction with workflow. 
+ * type of functionality wherever you need UI interaction with workflow.
  *
  * @author  marcus@silverstripe.com.au
  * @license BSD License (http://silverstripe.org/bsd-license/)
  * @package advancedworkflow
  */
 class AdvancedWorkflowExtension extends LeftAndMainExtension {
-	
+
 	private static $allowed_actions = array(
 		'updateworkflow',
-		'startworkflow'
+		'startworkflow',
+        'cancelembargoexpiry',
 	);
+
+    /**
+     * Handle cancelling the scheduled embargo and expiry dates
+     *
+     * @param $data
+     * @param $form
+     * @param $request
+     * @return HTMLText|ViewableData_Customised|void
+     */
+    public function cancelembargoexpiry($data, $form, $request)
+    {
+        $item = $form->getRecord();
+
+        if (!$item) {
+            return $this->owner->httpError(404,
+                _t('AdvancedWorkflowExtension.CANCEL_NOTFOUND', 'Unable to find the item to cancel embargo and expiry')
+            );
+        }
+        if (!$item->hasExtension('WorkflowEmbargoExpiryExtension')) {
+            return $this->owner->httpError(500,
+                _t('AdvancedWorkflowExtension.CANCEL_NOEXTENSION', 'Unable to locate embargo and expiry extension')
+            );
+        }
+        if (!$item->canCancelEmbargoExpiry()) {
+            return $this->owner->httpError(403,
+                _t('AdvancedWorkflowExtension.CANCEL_NOPERMISSION', 'Insufficient permissions to cancel embargo and expiry')
+            );
+        }
+        $this->saveAsDraftWithAction($form, $item);
+
+        // Shifting scheduled to desired after save draft, since they're not savable fields
+        if (!$item->DesiredPublishDate) {
+            $item->DesiredPublishDate = $item->PublishOnDate;
+        }
+        if (!$item->DesiredUnPublishDate) {
+            $item->DesiredUnPublishDate = $item->UnPublishOnDate;
+        }
+        $item->PublishOnDate = null;
+        $item->UnPublishOnDate = null;
+        $item->clearPublishJob();
+        $item->clearUnPublishJob();
+        $item->write();
+
+        return $this->returnResponse($form);
+    }
 
 	public function startworkflow($data, $form, $request) {
 		$item = $form->getRecord();
@@ -25,13 +71,13 @@ class AdvancedWorkflowExtension extends LeftAndMainExtension {
 		if (!$item || !$item->canEdit()) {
 			return;
 		}
-		
+
 		// Save a draft, if the user forgets to do so
 		$this->saveAsDraftWithAction($form, $item);
 
 		$svc = singleton('WorkflowService');
 		$svc->startWorkflow($item, $workflowID);
-		
+
 		return $this->returnResponse($form);
 	}
 
@@ -74,7 +120,7 @@ class AdvancedWorkflowExtension extends LeftAndMainExtension {
 			$this->owner->extend('updateWorkflowEditForm', $form);
 		}
 	}
-	
+
 	public function updateItemEditForm($form) {
 		$record = $form->getRecord();
 		if ($record && $record->hasExtension('WorkflowApplicable')) {
@@ -85,10 +131,10 @@ class AdvancedWorkflowExtension extends LeftAndMainExtension {
 	}
 
 	/**
-	 * Update a workflow based on user input. 
+	 * Update a workflow based on user input.
 	 *
 	 * @todo refactor with WorkflowInstance::updateWorkflow
-	 * 
+	 *
 	 * @param array $data
 	 * @param Form $form
 	 * @param SS_HTTPRequest $request
@@ -123,25 +169,25 @@ class AdvancedWorkflowExtension extends LeftAndMainExtension {
 
 		return $this->returnResponse($form);
 	}
-	
+
 	protected function returnResponse($form) {
 		if ($this->owner instanceof GridFieldDetailForm_ItemRequest) {
 			$record = $form->getRecord();
 			if ($record && $record->exists()) {
 				return $this->owner->edit($this->owner->getRequest());
 			}
-		} 
-		
+		}
+
 		$negotiator = method_exists($this->owner, 'getResponseNegotiator') ? $this->owner->getResponseNegotiator() : Controller::curr()->getResponseNegotiator();
 		return $negotiator->respond($this->owner->getRequest());
 	}
-	
+
 	/**
 	 * Ocassionally users forget to apply their changes via the standard CMS "Save Draft" button,
 	 * and select the action button instead - losing their changes.
 	 * Calling this from a controller method saves a draft automatically for the user, whenever a workflow action is run.
 	 * See: #72 and #77
-	 * 
+	 *
 	 * @param \Form $form
 	 * @param \DataObject $item
 	 * @return void
@@ -149,6 +195,6 @@ class AdvancedWorkflowExtension extends LeftAndMainExtension {
 	protected function saveAsDraftWithAction(Form $form, DataObject $item) {
 		$form->saveInto($item);
 		$item->write();
-	}	
+	}
 
 }

--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -24,11 +24,12 @@ if (!class_exists('QueuedJobDescriptor')) {
 class WorkflowEmbargoExpiryExtension extends DataExtension {
 
 	private static $db = array(
-		'DesiredPublishDate'	=> 'DBDatetime',
-		'DesiredUnPublishDate'	=> 'DBDatetime',
-		'PublishOnDate'			=> 'DBDatetime',
-		'UnPublishOnDate'		=> 'DBDatetime',
-		'AllowEmbargoedEditing' => 'Boolean',
+		'DesiredPublishDate'     => 'DBDatetime',
+		'DesiredUnPublishDate'   => 'DBDatetime',
+		'PublishOnDate'          => 'DBDatetime',
+		'UnPublishOnDate'        => 'DBDatetime',
+        'AllowEmbargoedEditing'  => 'Boolean',
+        'CanCancelEmbargoExpiry' => 'Boolean',
 	);
 
 	private static $has_one = array(
@@ -179,7 +180,7 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 	/**
 	 * Clears any existing publish job against this dataobject
 	 */
-	protected function clearPublishJob() {
+	public function clearPublishJob() {
 		$job = $this->owner->PublishJob();
 		if($job && $job->exists()) {
 			$job->delete();
@@ -190,7 +191,7 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 	/**
 	 * Clears any existing unpublish job
 	 */
-	protected function clearUnPublishJob() {
+    public function clearUnPublishJob() {
 		// Cancel any in-progress unpublish job
 		$job = $this->owner->UnPublishJob();
 		if ($job && $job->exists()) {
@@ -460,6 +461,36 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
         $unpublish = strtotime($this->owner->UnPublishOnDate);
 
         return $now < $unpublish;
+    }
+
+    /**
+     * Defines whether the "Cancel embargo & expiry" is allowed
+     *
+     * @return bool|null
+     */
+    public function canCancelEmbargoExpiry($member = null) {
+        // any embargo or expiry populated or in the past
+        if (!$this->owner->getIsPublishScheduled() &&
+            !$this->owner->getIsUnPublishScheduled()) {
+            return false;
+        }
+
+        // extension hook for overriding default behaviour
+        $permission = $this->owner->extend('canCancelWorkflowEmbargoExpiry');
+
+        if (!is_null($permission)) {
+            return $permission;
+        }
+
+        // has the override global permission
+        if (Permission::check('CANCEL_EMBARGO_EXPIRY_WORKFLOW')) {
+            return true;
+        }
+
+        // user has permission to publish and this has been enabled for cancelling
+        if ($this->owner->canPublish($member) && $this->owner->CanCancelEmbargoExpiry) {
+            return true;
+        }
     }
 
     /**

--- a/code/services/WorkflowService.php
+++ b/code/services/WorkflowService.php
@@ -442,6 +442,12 @@ class WorkflowService implements PermissionProvider {
                 'help'     => _t('AdvancedWorkflow.EDITEMBARGOHELP', 'Allow users to edit items that have been embargoed by a workflow'),
                 'sort'     => 5
             ),
+            'CANCEL_EMBARGO_EXPIRY_WORKFLOW' => array(
+                'name'     => _t('AdvancedWorkflow.CANCEL_EMBARGOEXPIRY', 'Cancel embargo and expiry'),
+                'category' => _t('AdvancedWorkflow.ADVANCED_WORKFLOW', 'Advanced Workflow'),
+                'help'     => _t('AdvancedWorkflow.CANCEL_EMBARGOEXPIRY_HELP', 'Users can cancel an embargo and expiry for a workflow approved page'),
+                'sort'     => 6
+            )
 		);
 	}
 

--- a/tests/WorkflowEmbargoExpiryTest.php
+++ b/tests/WorkflowEmbargoExpiryTest.php
@@ -375,6 +375,34 @@ class WorkflowEmbargoExpiryTest extends SapphireTest {
         $this->assertNotContains('expiry', array_keys($flags));
     }
 
+    /**
+     * Test the permission check for canCancelEmbargoExpiry
+     */
+    public function testCancelEmbargoExpiry()
+    {
+        $page = SiteTree::create();
+
+        // by default without Publish or UnPublish dates, it shouldn't be true
+        $this->assertFalse($page->canCancelEmbargoExpiry());
+
+        $page->PublishOnDate = '2020-01-01 00:00:00';
+        $page->UnPublishOnDate = '2020-01-02 00:00:00';
+
+        // has global permission to cancel
+        $memberID = $this->logInWithPermission('CANCEL_EMBARGO_EXPIRY_WORKFLOW');
+        $this->assertTrue($page->canCancelEmbargoExpiry());
+
+        $page->CanCancelEmbargoExpiry = true;
+
+        // flag is enabled for cancelling, but do not have publish permission
+        $this->logOut();
+        $this->assertNotTrue($page->canCancelEmbargoExpiry());
+
+        // sets canPublish() permission to true
+        $page->setIsPublishJobRunning(true);
+        $this->assertTrue($page->canCancelEmbargoExpiry());
+    }
+
 	/**
 	 * Test workflow definition "Can disable edits during embargo"
 	 * Make sure page cannot be edited when an embargo is in place


### PR DESCRIPTION
A new feature providing a straightforward way for CMS users to easily **cancel** an embargo and/or expiry for a workflow approved page.

---
## The problem

Currently there isn't a direct method for CMS users to cancel an approved embargo/expiry (after a workflow is completed).

To do this, the CMS user would have to either:
- Remove the jobs from queue (some users may have limited permissions and can't do this), or
- Push the page into a new workflow with new embargo/expiry dates
## A simplified UI

To simplify this, a new _Cancel Embargo & Expiry_ CMS action is available under _More Options_.

![screen shot 2016-06-16 at 2 34 32 pm](https://cloud.githubusercontent.com/assets/7202667/16103768/849b707a-33cf-11e6-83e2-46b73d478124.png)

When clicked: 
1. it removes the embargo/expiry jobs from queue, and 
2. brings the page back to the draft state. 

This link is only available for pages with active embargo and/or expiry.
## An example step-by-step scenario

Below illustrates an example scenario:
1. CMS user makes changes to a page
2. Assigns an embargo and expiry date and time
3. Pushes the page into an active workflow
4. The workflow is approved, embargo and expiry are in the queue
5. Later on, the CMS user decides not to proceed with the embargo and expiry, opens up _More Options_ and clicks _Cancel Embargo & Expiry_
   ![screen shot 2016-06-16 at 2 31 46 pm](https://cloud.githubusercontent.com/assets/7202667/16103742/36b61c02-33cf-11e6-89ac-3085da8b30a7.png)
6. The embargo and expiry jobs are removed from queue, and page is returned to the draft state
7. The CMS user can make further edits to content or change dates, and then push it back into the workflow
## Notes
### Pre-populating Publishing Schedule date & time values

After cancelling, the desired publish and unpublish dates are pre-populated with the previous set dates, this provisions oversights for setting dates again. 

For example, a CMS user cancels an embargo due to a typo, the correction is saved in the Content tab and then pushed back into a new workflow. The CMS user have ignored checking the _Publishing Schedule_ tab, but since the desired date & time field are pre-populated the page will be embargoed with the same date as before.
