### PR TITLE
3.8: Do not override TimeField's timeformat config setting.

### DIFF
--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -142,8 +142,11 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 
 		$dt->getDateField()->setConfig('showcalendar', true);
 		$ut->getDateField()->setConfig('showcalendar', true);
-		$dt->getTimeField()->setConfig('timeformat', 'HH:mm:ss');
-		$ut->getTimeField()->setConfig('timeformat', 'HH:mm:ss');
+
+		if ($dt->getTimeField()->getConfig('timeformat') === null) {
+			$dt->getTimeField()->setConfig('timeformat', 'HH:mm:ss');
+			$ut->getTimeField()->setConfig('timeformat', 'HH:mm:ss');
+		}
 
 		// Enable a jQuery-UI timepicker widget
 		if(self::$showTimePicker) {


### PR DESCRIPTION
**Problem:**

1. Workflow has "allow editing" turned off.
2. An Admin changes their preferred time format from "my profile" (`/admin/myprofile/`) to (for example) `H:mm` rather than the default `HH:mm:ss`.
3. Admin submits an item with an Embargo date set for Workflow approval.
4. Admin attempts to reject/cancel/approve the Workflow.
5. Admin is presented with a validation error: "Please enter a valid time format (HH:mm:ss)".

I'm not really sure what the original reason was for always setting the `TimeField`'s time format to "HH:mm:ss" in `updateCMSFields`, but doing so is overriding the time format that it would otherwise use from the admin's profile settings.

I didn't want to just remove this setter, but can we please not override the time format if it has already been set by something else?