### PR TITLE
Add ability to lock Embargo publishing to a specific Version number (rather than just "Stage")

### DIFF
--- a/code/actions/PublishItemWorkflowAction.php
+++ b/code/actions/PublishItemWorkflowAction.php
@@ -26,7 +26,11 @@ class PublishItemWorkflowAction extends WorkflowAction {
 		}
 
 		if (class_exists('AbstractQueuedJob') && $this->PublishDelay) {
-			$job   = new WorkflowPublishTargetJob($target);
+			$version = null;
+			if ($target->hasField('Version')) {
+				$version = $target->getField('Version');
+			}
+			$job   = new WorkflowPublishTargetJob($target, 'publish', $version);
 			$days  = $this->PublishDelay;
 			$after = date('Y-m-d H:i:s', strtotime("+$days days"));
 			singleton('QueuedJobService')->queueJob($job, $after);

--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -194,8 +194,13 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 			$this->clearPublishJob();
 		}
 
+		$version = null;
+		if ($this->owner->hasField('Version')) {
+			$version = $this->owner->getField('Version');
+		}
+
 		// Create a new job with the specified schedule
-		$job = new WorkflowPublishTargetJob($this->owner, 'publish');
+		$job = new WorkflowPublishTargetJob($this->owner, 'publish', $version);
 		$this->owner->PublishJobID = Injector::inst()->get('QueuedJobService')
 				->queueJob($job, $when ? date('Y-m-d H:i:s', $when) : null);
 	}

--- a/docs/en/userguide/embargo-advanced-setup.md
+++ b/docs/en/userguide/embargo-advanced-setup.md
@@ -1,0 +1,52 @@
+## Advanced Embargo and Expirty
+
+### Publish target by version
+The `WorkflowPublishTargetJob` supports publishing a specific (approved) version of a DataObject, however, it requires
+some extra steps on our part.
+
+`Versioned::publish()` supports the publication of a specific version number to a specific stage, however, in
+`SiteTree:doPublish()` we can see that the usage of `$this->publish(..)` is hard coded to always publish from "Stage" to
+"Live".
+
+To get around this, you will need to do two things.
+
+#### First
+You will need to implement a new method onto your Versioned DataObjects called `doVersionPublish`. This method, at the
+very least, will need to call `publish()`, but you could do anything/everything else from `doPublish()` as well.
+
+Where you implement this method is up to you. In the example below, we've added `doVersionPublish` to a `DataExtension`
+which has been applied to `SiteTree`:
+
+	public function doVersionPublish()
+    {
+        if (!$this->owner->canPublish()) {
+            return false;
+        }
+
+        $stage = 'Stage';
+        if ($this->owner->hasField('Version')) {
+            $stage = $this->owner->getField('Version');
+        }
+
+        // Handle activities undertaken by extensions
+        $this->owner->invokeWithExtensions('onBeforePublish', $original);
+        $this->owner->write();
+        $this->owner->publish($stage, "Live");
+
+        // Handle activities undertaken by extensions
+        $this->owner->invokeWithExtensions('onAfterPublish', $original);
+
+        return true;
+    }
+
+Our `publish()` method now looks for a field called `Version` on our DataObject, and if it's available, it uses that as
+the Stage. Which brings us to,
+
+#### Second
+Your Versioned DataObjects will need to have an available database field called `Version` (by default, anything
+extending `SiteTree` will have this field). This value is passed to the `WorkflowPublishTargetJob` **at the time of
+approval**. `WorkflowPublishTargetJob::process` will then retrieve **this** version of your DataObject, and call
+`doVersionPublish` on that DataObject.
+
+Because `doVersionPublish` is called on that specific version of your DataObject, it will know what version number it
+is, and when `publish($stage, "Live")` is called, it will publish that specific version.

--- a/docs/en/userguide/index.md
+++ b/docs/en/userguide/index.md
@@ -14,3 +14,4 @@ Make sure that your SilverStripe CMS installation has the [Advanced Workflow](ht
  - [Workflow users and permissions](workflow-permissions.md)
  - [Advanced workflow setup](workflow-advanced-setup.md)
  - [Exporting and importing workflows](workflow-export-import.md)
+ - [Advanced embargo and expiry setup](embargo-advanced-setup.md)


### PR DESCRIPTION
**Problem**

1. An Object has gone through Workflow approval and now sits ready to publish with an Embargo date (`version 1` approved).
2. For [whatever reason], the draft state for this Object is edited prior to publishing (now `version 2`). These changes do *not* go through Workflow approval.
3. When the Embargo ends, whatever content is currently in "Stage" (`version 2`) is published, regardless of whether it was approved or not.

This is due to the fact that `doPublish` always publishes from "Stage" to "Live".

**Proposal**

1. If the requested Object has a `Version` field available, then store that `Version` against the `WorkflowPublishTargetJob`.
2. Allow the developer to then implement a method on those Objects called `doVersionPublish` if he wishes to lock down his publishing by `Version`.
3. If `Version` and `doVersionPublish` exist, then do that rather than `doPublish`.

The developer can make their `doVersionPublish` method do whatever it is they decide is necessary.

**Notes/thoughts**
I thought about extending `SiteTree`, overriding `doPublish`, and having all of my Pages extend from there, but I'd still need the version passed to `WorkflowPublishTargetJob` in order for that to work. That method (I think) also makes things a little ambiguous. You might look at the Job and think that it's publishing your `Version` when actually it's not (because you haven't overridden `doPublish`).

I'm **definitely** open to other suggestions/solutions, but I think that this solution impacts the module the least, and if a developer goes in to see how the Job works, hopefully it's clear what they need to implement in order to publish a specific `Version`, rather than just publishing "Stage".