### PR TITLE
Update .editorconfig to match current module tab format.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@
 charset = utf-8
 end_of_line = lf
 indent_size = 4
-indent_style = space
+indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
Update `.editorconfig` to match the indent style that is currently being used throughout the module.

I would be more than happy to go through and update everything to spaces (and even update to PSR-2 if that is desired), but the issue I raised for that got no traction.