### PR TITLE
WorkflowApplicable extension currently not singleton safe

### DIFF
--- a/_config/workflowconfig.yml
+++ b/_config/workflowconfig.yml
@@ -1,6 +1,11 @@
 ---
 Name: workflowconfig
 ---
+SilverStripe\Core\Injector\Injector:
+  Symbiote\AdvancedWorkflow\Extensions\WorkflowApplicable:
+    class: Symbiote\AdvancedWorkflow\Extensions\WorkflowApplicable
+    type: prototype
+    
 SilverStripe\CMS\Model\SiteTree:
   extensions:
     - Symbiote\AdvancedWorkflow\Extensions\WorkflowApplicable


### PR DESCRIPTION
Temporarily run it as a prototype instead of singleton
See https://github.com/silverstripe/silverstripe-framework/issues/7382