### PR TITLE
FIX Update ownerBaseClass in WorkflowApplicable for SS4 and convert to vendor module

### DIFF
--- a/code/admin/AdvancedWorkflowAdmin.php
+++ b/code/admin/AdvancedWorkflowAdmin.php
@@ -86,11 +86,9 @@ class AdvancedWorkflowAdmin extends ModelAdmin
     {
         parent::init();
 
-        $module = ModuleLoader::getModule('symbiote/silverstripe-advancedworkflow');
-
-        Requirements::add_i18n_javascript($module->getRelativeResourcePath('client/lang'));
-        Requirements::javascript($module->getRelativeResourcePath('client/dist/js/advancedworkflow.js'));
-        Requirements::css($module->getRelativeResourcePath('client/dist/styles/advancedworkflow.css'));
+        Requirements::add_i18n_javascript('symbiote/silverstripe-advancedworkflow:client/lang');
+        Requirements::javascript('symbiote/silverstripe-advancedworkflow:client/dist/js/advancedworkflow.js');
+        Requirements::css('symbiote/silverstripe-advancedworkflow:client/dist/styles/advancedworkflow.css');
     }
 
     /*

--- a/code/extensions/AdvancedWorkflowExtension.php
+++ b/code/extensions/AdvancedWorkflowExtension.php
@@ -54,8 +54,7 @@ class AdvancedWorkflowExtension extends Extension
      */
     public function updateEditForm(Form $form)
     {
-        $module = ModuleLoader::getModule('symbiote/silverstripe-advancedworkflow');
-        Requirements::javascript($module->getRelativeResourcePath('client/dist/js/advancedworkflow.js'));
+        Requirements::javascript('symbiote/silverstripe-advancedworkflow:client/dist/js/advancedworkflow.js');
         $svc    = singleton(WorkflowService::class);
         $p      = $form->getRecord();
         $active = $svc->getWorkflowFor($p);

--- a/code/extensions/WorkflowApplicable.php
+++ b/code/extensions/WorkflowApplicable.php
@@ -305,7 +305,7 @@ class WorkflowApplicable extends DataExtension
     public function WorkflowInstances()
     {
         return WorkflowInstance::get()->filter(array(
-            'TargetClass' => $this->ownerBaseClass,
+            'TargetClass' => $this->owner->baseClass(),
             'TargetID'    => $this->owner->ID
         ));
     }

--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -93,23 +93,21 @@ class WorkflowEmbargoExpiryExtension extends DataExtension
         // requirements
         // ------------
 
-        $module = ModuleLoader::getModule('symbiote/silverstripe-advancedworkflow');
-
-        Requirements::add_i18n_javascript($module->getRelativeResourcePath('client/lang'));
+        Requirements::add_i18n_javascript('symbiote/silverstripe-advancedworkflow:client/lang');
 
         // Add timepicker functionality
         // @see https://github.com/trentrichardson/jQuery-Timepicker-Addon
         Requirements::css(
-            $module->getRelativeResourcePath('thirdparty/javascript/jquery-ui/timepicker/jquery-ui-timepicker-addon.css')
+            'symbiote/silverstripe-advancedworkflow:thirdparty/javascript/jquery-ui/timepicker/jquery-ui-timepicker-addon.css'
         );
-        Requirements::css($module->getRelativeResourcePath('client/dist/styles/advancedworkflow.css'));
+        Requirements::css('symbiote/silverstripe-advancedworkflow:client/dist/styles/advancedworkflow.css');
         Requirements::javascript(
-            $module->getRelativeResourcePath('thirdparty/javascript/jquery-ui/timepicker/jquery-ui-sliderAccess.js')
+            'symbiote/silverstripe-advancedworkflow:thirdparty/javascript/jquery-ui/timepicker/jquery-ui-sliderAccess.js'
         );
         Requirements::javascript(
-            $module->getRelativeResourcePath('thirdparty/javascript/jquery-ui/timepicker/jquery-ui-timepicker-addon.js')
+            'symbiote/silverstripe-advancedworkflow:thirdparty/javascript/jquery-ui/timepicker/jquery-ui-timepicker-addon.js'
         );
-        Requirements::javascript($module->getRelativeResourcePath('client/dist/js/advancedworkflow.js'));
+        Requirements::javascript('symbiote/silverstripe-advancedworkflow:client/dist/js/advancedworkflow.js');
 
         // Fields
         // ------

--- a/code/formfields/WorkflowField.php
+++ b/code/formfields/WorkflowField.php
@@ -95,10 +95,8 @@ class WorkflowField extends FormField
 
     public function FieldHolder($properties = array())
     {
-        $workflow = ModuleLoader::getModule('symbiote/silverstripe-advancedworkflow');
-
-        Requirements::javascript($workflow->getRelativeResourcePath('client/dist/js/advancedworkflow.js'));
-        Requirements::css($workflow->getRelativeResourcePath('client/dist/styles/advancedworkflow.css'));
+        Requirements::javascript('symbiote/silverstripe-advancedworkflow:client/dist/js/advancedworkflow.js');
+        Requirements::css('symbiote/silverstripe-advancedworkflow:client/dist/styles/advancedworkflow.css');
 
         return $this->Field($properties);
     }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "symbiote/silverstripe-advancedworkflow",
     "description": "Adds configurable workflow support to the CMS, with a GUI for creating custom workflow definitions.",
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "keywords": ["silverstripe", "advancedworkflow", "workflow"],
     "license": "BSD-3-Clause",
     "authors": [
@@ -26,10 +26,14 @@
         "squizlabs/php_codesniffer": "^3.0"
     },
     "extra": {
-        "installer-name": "advancedworkflow",
         "branch-alias": {
             "dev-master": "5.0.x-dev"
-        }
+        },
+        "expose": [
+            "client/dist",
+            "client/lang",
+            "images"
+        ]
     },
     "suggest": {
         "symbiote/silverstripe-queuedjobs": "Allow automated workflow transitions with queued system jobs"


### PR DESCRIPTION
Switches to a vendor module, meaning it will be installed into `vendor/symbiote`. This requires "exposing" the client/dist and client/lang folders, as well as the images folder.

Also fix the user of ownerBaseClass which has been removed from core.

Fixes #322 