### PR TITLE
FIX Remove use of FormField::$dontEscape (gone) and replace with HTMLText

### DIFF
--- a/code/dataobjects/WorkflowActionInstance.php
+++ b/code/dataobjects/WorkflowActionInstance.php
@@ -8,6 +8,7 @@ use SilverStripe\Forms\ReadonlyField;
 use SilverStripe\Forms\TextareaField;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\Security\Member;
 
 /**
@@ -63,8 +64,11 @@ class WorkflowActionInstance extends DataObject
         $fieldDiff = $this->Workflow()->getTargetDiff();
 
         foreach ($fieldDiff as $field) {
-            $display = ReadonlyField::create('workflow-' . $field->Name, $field->Title, $field->Diff)
-                ->setDontEscape(true)
+            $display = ReadonlyField::create(
+                'workflow-' . $field->Name,
+                $field->Title,
+                DBField::create_field('HTMLText', $field->Diff)
+            )
                 ->addExtraClass('workflow-field-diff');
             $fields->push($display);
         }


### PR DESCRIPTION
`FormField::$dontEscape` was removed in https://github.com/silverstripe/silverstripe-framework/commit/5c9044a007d3e0e49d5a57f8794c71717a5aa5d1 - this is the replacement for it by casting the diff content as an HTMLText field.

Could be the fix for #330...?