### PR TITLE
FIX revert to cascading permission checks for canWorkflowPublish

### DIFF
--- a/src/DataObjects/WorkflowDefinition.php
+++ b/src/DataObjects/WorkflowDefinition.php
@@ -482,12 +482,7 @@ class WorkflowDefinition extends DataObject
      */
     public function canWorkflowPublish($member, $target)
     {
-        $publish = $this->extendedCan('canWorkflowPublish', $member, $target);
-
-        if (is_null($publish)) {
-            return false;
-        }
-        return $publish;
+        return $this->extendedCan('canWorkflowPublish', $member, $target);
     }
 
     /**

--- a/src/DataObjects/WorkflowDefinition.php
+++ b/src/DataObjects/WorkflowDefinition.php
@@ -482,7 +482,11 @@ class WorkflowDefinition extends DataObject
      */
     public function canWorkflowPublish($member, $target)
     {
-        return $this->extendedCan('canWorkflowPublish', $member, $target);
+        $publish = $this->extendedCan('canWorkflowPublish', $member, $target);
+        if (is_null($publish)) {
+            $publish = Permission::checkMember($member, 'ADMIN');
+        }
+        return $publish;
     }
 
     /**


### PR DESCRIPTION
SiteTree::canPublish leverages DataExtensions to delegate permission checking,
and falling back to checking for administrative or canEdit priviliges when
NULL is returned, and strictly NULL (ie. not FALSE or 0). However
WorkflowDefinition::canWorkflowPublish short circuits this by explicitly
returning FALSE when a NULL value is detected, meaning SiteTree's default
fallbacks are never checked. This had an unfortunate side effect of not letting
and user with ADMIN permissions `Save & Publish` a page while applying a workflow
for the first time. By no longer short circuiting and re-instating the default
cascade of checks, we resolve this fatal error.

Resolves #333 

Thank you @nyeholt for your help!