### PR TITLE
FIX Content should be readonly while processing

### DIFF
--- a/src/Services/WorkflowService.php
+++ b/src/Services/WorkflowService.php
@@ -4,6 +4,7 @@ namespace Symbiote\AdvancedWorkflow\Services;
 
 use Exception;
 use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Convert;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
@@ -182,7 +183,11 @@ class WorkflowService implements PermissionProvider
         } elseif (is_object($item) && ($item->hasExtension(WorkflowApplicable::class)
                 || $item->hasExtension(FileWorkflowApplicable::class))
         ) {
-            $filter = sprintf('"TargetClass" = \'%s\' AND "TargetID" = %d', ClassInfo::baseDataClass($item), $item->ID);
+            $filter = sprintf(
+                '"TargetClass" = \'%s\' AND "TargetID" = %d',
+                Convert::raw2sql(ClassInfo::baseDataClass($item)),
+                $item->ID
+            );
             $complete = $includeComplete ? 'OR "WorkflowStatus" = \'Complete\' ' : '';
             return DataObject::get_one(
                 WorkflowInstance::class,


### PR DESCRIPTION
After e.g. a simple 2 step workflow of "request approval" to "publish" has
begun, content should no longer be editable by the content author until
the reviewer has either approved or denied the changes. This was broken by
a bad where clause resulting in the system thinking there were no
in-progress workflows. Fix this by escaping strings correctly for the
active database connection (via `Convert` utility class).

Resolves #349 