### PR TITLE
FIX Update path to template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
 before_script:
   - phpenv rehash
   - phpenv config-rm xdebug.ini
+  - echo 'memory_limit = 2G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
   - composer validate
   - composer require --no-update silverstripe/recipe-cms:$RECIPE_VERSION symbiote/silverstripe-queuedjobs:4.x-dev

--- a/src/Forms/gridfield/GridFieldWorkflowRestrictedEditButton.php
+++ b/src/Forms/gridfield/GridFieldWorkflowRestrictedEditButton.php
@@ -4,6 +4,7 @@ namespace Symbiote\AdvancedWorkflow\Forms\GridField;
 
 use SilverStripe\Control\Controller;
 use SilverStripe\Forms\GridField\GridField_ColumnProvider;
+use SilverStripe\Forms\GridField\GridFieldEditButton;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\Security;
 use SilverStripe\View\ArrayData;
@@ -92,6 +93,6 @@ class GridFieldWorkflowRestrictedEditButton implements GridField_ColumnProvider
         $data = new ArrayData(array(
             'Link' => Controller::join_links($gridField->Link('item'), $record->ID, 'edit')
         ));
-        return $data->renderWith('Includes/GridFieldEditButton');
+        return $data->renderWith(GridFieldEditButton::class);
     }
 }


### PR DESCRIPTION
The template reference pointed to an outdated path and caused a user warning. This has been fixed within this commit.