### PR TITLE
FIX Admin users can always edit records that have active workflow transitions

### DIFF
--- a/src/DataObjects/WorkflowAction.php
+++ b/src/DataObjects/WorkflowAction.php
@@ -13,6 +13,8 @@ use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\Permission;
+use SilverStripe\Security\Security;
 
 /**
  * A workflow action describes a the 'state' a workflow can be in, and
@@ -70,11 +72,18 @@ class WorkflowAction extends DataObject
      * will try and figure out an appropriate value for the actively running workflow
      * if null is returned from this method.
      *
+     * Admin level users can always edit.
+     *
      * @param  DataObject $target
      * @return bool
      */
     public function canEditTarget(DataObject $target)
     {
+        $currentUser = Security::getCurrentUser();
+        if ($currentUser && Permission::checkMember($currentUser, 'ADMIN')) {
+            return true;
+        }
+
         return null;
     }
 

--- a/src/Extensions/WorkflowApplicable.php
+++ b/src/Extensions/WorkflowApplicable.php
@@ -18,12 +18,14 @@ use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TabSet;
 use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\ORM\DataExtension;
+use SilverStripe\ORM\DataList;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\Security;
+use Symbiote\AdvancedWorkflow\DataObjects\WorkflowActionInstance;
 use Symbiote\AdvancedWorkflow\DataObjects\WorkflowDefinition;
 use Symbiote\AdvancedWorkflow\DataObjects\WorkflowInstance;
 use Symbiote\AdvancedWorkflow\Services\WorkflowService;
-use Symbiote\QueuedJobs\Service\AbstractQueuedJob;
+use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 
 /**
  * DataObjects that have the WorkflowApplicable extension can have a
@@ -80,7 +82,7 @@ class WorkflowApplicable extends DataExtension
      */
     public function isPublishJobRunning()
     {
-        $propIsSet = $this->getIsPublishJobRunning() ? true : false;
+        $propIsSet = (bool) $this->getIsPublishJobRunning();
         return class_exists(AbstractQueuedJob::class) && $propIsSet;
     }
 
@@ -351,7 +353,7 @@ class WorkflowApplicable extends DataExtension
     /**
      * Gets the history of a workflow instance
      *
-     * @return DataObjectSet
+     * @return DataList
      */
     public function getWorkflowHistory($limit = null)
     {
@@ -411,6 +413,8 @@ class WorkflowApplicable extends DataExtension
 
     /**
      * Can only edit content that's NOT in another person's content changeset
+     *
+     * @return bool
      */
     public function canEdit($member)
     {
@@ -420,12 +424,14 @@ class WorkflowApplicable extends DataExtension
         }
 
         if ($active = $this->getWorkflowInstance()) {
-            return $active->canEditTarget($this->owner);
+            return $active->canEditTarget();
         }
     }
 
     /**
      * Can a user edit the current workflow attached to this item?
+     *
+     * @return bool
      */
     public function canEditWorkflow()
     {

--- a/tests/DataObjects/WorkflowActionTest.php
+++ b/tests/DataObjects/WorkflowActionTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symbiote\AdvancedWorkflow\Tests\DataObjects;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DataObject;
+use Symbiote\AdvancedWorkflow\DataObjects\WorkflowAction;
+
+class WorkflowActionTest extends SapphireTest
+{
+    protected $usesDatabase = true;
+
+    public function testAdminUsersCanAlwaysEdit()
+    {
+        $this->logInWithPermission('ADMIN');
+        $action = new WorkflowAction();
+        $this->assertTrue($action->canEditTarget(new DataObject));
+    }
+}


### PR DESCRIPTION
Also updates some docblocks and syntax for consistency

Fixes #358