### PR TITLE
fix(WorkflowInstance) Don't let a diff failure kill the whole CMS load

### DIFF
--- a/src/DataObjects/WorkflowInstance.php
+++ b/src/DataObjects/WorkflowInstance.php
@@ -295,7 +295,12 @@ class WorkflowInstance extends DataObject
         $diff = DataDifferencer::create($liveTarget, $draftTarget);
         $diff->ignoreFields($this->config()->get('diff_ignore_fields'));
 
-        $fields = $diff->ChangedFields();
+        $fields = ArrayList::create();
+        try {
+            $fields = $diff->ChangedFields();
+        } catch (\InvalidArgumentException $iae) {
+            // noop
+        }
 
         return $fields;
     }


### PR DESCRIPTION
This isn't the most elegant solution, but there's apparently several failure scenarios here (multivalue fields in particular, I think some Composite fields will trigger the issue too) that will make it impossible to load the page in the CMS. 