### PR TITLE
FIX Use getter/setters for WorkflowService dependency

### DIFF
--- a/src/Admin/AdvancedWorkflowAdmin.php
+++ b/src/Admin/AdvancedWorkflowAdmin.php
@@ -300,10 +300,10 @@ class AdvancedWorkflowAdmin extends ModelAdmin
     public function getFieldDependentData(Member $user, $fieldName)
     {
         if ($fieldName == 'PendingObjects') {
-            return $this->workflowService->userPendingItems($user);
+            return $this->getWorkflowService()->userPendingItems($user);
         }
         if ($fieldName == 'SubmittedObjects') {
-            return $this->workflowService->userSubmittedItems($user);
+            return $this->getWorkflowService()->userSubmittedItems($user);
         }
     }
 
@@ -353,5 +353,23 @@ class AdvancedWorkflowAdmin extends ModelAdmin
         $form->setActions($newActionList);
 
         return $form;
+    }
+
+    /**
+     * @param WorkflowService $workflowService
+     * @return $this
+     */
+    public function setWorkflowService(WorkflowService $workflowService)
+    {
+        $this->workflowService = $workflowService;
+        return $this;
+    }
+
+    /**
+     * @return WorkflowService
+     */
+    public function getWorkflowService()
+    {
+        return $this->workflowService;
     }
 }

--- a/src/DataObjects/WorkflowDefinition.php
+++ b/src/DataObjects/WorkflowDefinition.php
@@ -140,7 +140,7 @@ class WorkflowDefinition extends DataObject
             $this->TemplateVersion = null;
         }
         if ($this->numChildren() == 0 && $this->Template && !$this->TemplateVersion) {
-            $this->workflowService->defineFromTemplate($this, $this->Template);
+            $this->getWorkflowService()->defineFromTemplate($this, $this->Template);
         }
     }
 
@@ -253,7 +253,7 @@ class WorkflowDefinition extends DataObject
 
         if ($this->ID) {
             if ($this->Template) {
-                $template = $this->workflowService->getNamedTemplate($this->Template);
+                $template = $this->getWorkflowService()->getNamedTemplate($this->Template);
                 $fields->addFieldToTab(
                     'Root.Main',
                     new ReadonlyField('Template', $this->fieldLabel('Template'), $this->Template)
@@ -283,7 +283,7 @@ class WorkflowDefinition extends DataObject
             ));
         } else {
             // add in the 'template' info
-            $templates = $this->workflowService->getTemplates();
+            $templates = $this->getWorkflowService()->getTemplates();
 
             if (is_array($templates)) {
                 $items = ['' => ''];
@@ -394,7 +394,7 @@ class WorkflowDefinition extends DataObject
     public function updateAdminActions($actions)
     {
         if ($this->Template) {
-            $template = $this->workflowService->getNamedTemplate($this->Template);
+            $template = $this->getWorkflowService()->getNamedTemplate($this->Template);
             if ($template && $this->TemplateVersion != $template->getVersion()) {
                 $label = sprintf(_t(
                     'WorkflowDefinition.UPDATE_FROM_TEMLPATE',
@@ -408,7 +408,7 @@ class WorkflowDefinition extends DataObject
     public function updateFromTemplate()
     {
         if ($this->Template) {
-            $template = $this->workflowService->getNamedTemplate($this->Template);
+            $template = $this->getWorkflowService()->getNamedTemplate($this->Template);
             $template->updateDefinition($this);
         }
     }
@@ -572,5 +572,23 @@ class WorkflowDefinition extends DataObject
         if (Permission::checkMember($member, "VIEW_ACTIVE_WORKFLOWS")) {
             return true;
         }
+    }
+
+    /**
+     * @param WorkflowService $workflowService
+     * @return $this
+     */
+    public function setWorkflowService(WorkflowService $workflowService)
+    {
+        $this->workflowService = $workflowService;
+        return $this;
+    }
+
+    /**
+     * @return WorkflowService
+     */
+    public function getWorkflowService()
+    {
+        return $this->workflowService;
     }
 }

--- a/src/Extensions/FileWorkflowApplicable.php
+++ b/src/Extensions/FileWorkflowApplicable.php
@@ -32,7 +32,7 @@ class FileWorkflowApplicable extends WorkflowApplicable
 
         // add the workflow fields directly. It's a requirement of workflow on file objects
         // that CMS admins mark the workflow step as being editable for files to be administerable
-        $active = $this->workflowService->getWorkflowFor($this->owner);
+        $active = $this->getWorkflowService()->getWorkflowFor($this->owner);
         if ($active) {
             $current = $active->CurrentAction();
             $wfFields = $active->getWorkflowFields();
@@ -53,7 +53,7 @@ class FileWorkflowApplicable extends WorkflowApplicable
     {
         parent::onAfterWrite();
 
-        $workflow = $this->workflowService->getWorkflowFor($this->owner);
+        $workflow = $this->getWorkflowService()->getWorkflowFor($this->owner);
         $rawData = $this->owner->toMap();
         if ($workflow && $this->owner->TransitionID) {
             // we want to transition, so do so if that's a valid transition to take.
@@ -78,7 +78,7 @@ class FileWorkflowApplicable extends WorkflowApplicable
             if (isset($rawData['TransitionID']) && $rawData['TransitionID']) {
                 // unset the transition ID so this doesn't get re-executed
                 $this->owner->TransitionID = null;
-                $this->workflowService->executeTransition($this->owner, $rawData['TransitionID']);
+                $this->getWorkflowService()->executeTransition($this->owner, $rawData['TransitionID']);
             } else {
                 // otherwise, just try to execute the current workflow to see if it
                 // can now proceed based on user input

--- a/src/Extensions/WorkflowApplicable.php
+++ b/src/Extensions/WorkflowApplicable.php
@@ -131,7 +131,7 @@ class WorkflowApplicable extends DataExtension
                 'WorkflowDefinitionID',
                 _t('WorkflowApplicable.DEFINITION', 'Applied Workflow')
             );
-            $definitions = $this->workflowService->getDefinitions()->map()->toArray();
+            $definitions = $this->getWorkflowService()->getDefinitions()->map()->toArray();
             $definition->setSource($definitions);
             $definition->setEmptyString(_t('WorkflowApplicable.INHERIT', 'Inherit from parent'));
             $tab->push($definition);
@@ -179,7 +179,7 @@ class WorkflowApplicable extends DataExtension
 
     public function updateCMSActions(FieldList $actions)
     {
-        $active = $this->workflowService->getWorkflowFor($this->owner);
+        $active = $this->getWorkflowService()->getWorkflowFor($this->owner);
         $c = Controller::curr();
         if ($c && $c->hasExtension(AdvancedWorkflowExtension::class)) {
             if ($active) {
@@ -225,7 +225,7 @@ class WorkflowApplicable extends DataExtension
                 }
             } else {
                 // Instantiate the workflow definition initial actions.
-                $definitions = $this->workflowService->getDefinitionsFor($this->owner);
+                $definitions = $this->getWorkflowService()->getDefinitionsFor($this->owner);
                 if ($definitions) {
                     $menu = $actions->fieldByName('ActionMenus');
                     if (is_null($menu)) {
@@ -343,7 +343,7 @@ class WorkflowApplicable extends DataExtension
     public function getWorkflowInstance()
     {
         if (!$this->currentInstance) {
-            $this->currentInstance = $this->workflowService->getWorkflowFor($this->owner);
+            $this->currentInstance = $this->getWorkflowService()->getWorkflowFor($this->owner);
         }
 
         return $this->currentInstance;
@@ -357,7 +357,7 @@ class WorkflowApplicable extends DataExtension
      */
     public function getWorkflowHistory($limit = null)
     {
-        return $this->workflowService->getWorkflowHistoryFor($this->owner, $limit);
+        return $this->getWorkflowService()->getWorkflowHistoryFor($this->owner, $limit);
     }
 
     /**
@@ -397,7 +397,7 @@ class WorkflowApplicable extends DataExtension
         }
 
         // use definition to determine if publishing directly is allowed
-        $definition = $this->workflowService->getDefinitionFor($this->owner);
+        $definition = $this->getWorkflowService()->getDefinitionFor($this->owner);
 
         if ($definition) {
             if (!Security::getCurrentUser()) {
@@ -440,5 +440,23 @@ class WorkflowApplicable extends DataExtension
             return $active->canEdit();
         }
         return false;
+    }
+
+    /**
+     * @param WorkflowService $workflowService
+     * @return $this
+     */
+    public function setWorkflowService(WorkflowService $workflowService)
+    {
+        $this->workflowService = $workflowService;
+        return $this;
+    }
+
+    /**
+     * @return WorkflowService
+     */
+    public function getWorkflowService()
+    {
+        return $this->workflowService;
     }
 }


### PR DESCRIPTION
In the next major version we should make the public $workflowService property protected
and use these getter/setters instead.