### PR TITLE
API Deprecate $showTimePicker. It is not used any longer and will be removed in 6.

### DIFF
--- a/src/Extensions/WorkflowEmbargoExpiryExtension.php
+++ b/src/Extensions/WorkflowEmbargoExpiryExtension.php
@@ -58,7 +58,10 @@ class WorkflowEmbargoExpiryExtension extends DataExtension
         'AllowEmbargoedEditing' => true
     );
 
-    // This "config" option, might better be handled in _config
+    /**
+     * @deprecated 5.2.0:6.0.0 This setting does nothing and will be removed in in 6.0
+     * @var bool
+     */
     public static $showTimePicker = true;
 
     /**


### PR DESCRIPTION
Implementation of this is removed in https://github.com/symbiote/silverstripe-advancedworkflow/pull/380

This is adding a deprecation notice since we can't remove it until the next major version.

It's not used anymore - #380 removes its actual implementation, but the functionality has never worked in SilverStripe 4.

Issue: #377