### PR TITLE
Enable updating getEditForm after it loads

### DIFF
--- a/src/Admin/AdvancedWorkflowAdmin.php
+++ b/src/Admin/AdvancedWorkflowAdmin.php
@@ -194,6 +194,8 @@ class AdvancedWorkflowAdmin extends ModelAdmin
             $grid->getConfig()->removeComponentsByType(GridFieldImportButton::class);
         }
 
+        $this->extend('updateEditFormAfter', $form);
+        
         return $form;
     }
 


### PR DESCRIPTION
A post hook here gives the ability to modify the gridfield after load. I used this on my fork to create a gridfield per subsite, and filtered the "pending" items to only those that belong to that subsite. Let me know if this is not the correct PR target. Addresses issue https://github.com/symbiote/silverstripe-advancedworkflow/issues/379