### PR TITLE
Remove workflow button from archived pages

### DIFF
--- a/src/Extensions/WorkflowApplicable.php
+++ b/src/Extensions/WorkflowApplicable.php
@@ -181,7 +181,7 @@ class WorkflowApplicable extends DataExtension
     {
         $active = $this->getWorkflowService()->getWorkflowFor($this->owner);
         $c = Controller::curr();
-        if ($c && $c->hasExtension(AdvancedWorkflowExtension::class)) {
+        if ($c && $c->hasExtension(AdvancedWorkflowExtension::class) && !$this->owner->isArchived()) {
             if ($active) {
                 if ($this->canEditWorkflow()) {
                     $workflowOptions = new Tab(


### PR DESCRIPTION
This PR removes the workflow options from archived page.
Similar to #284 which didn't make it to master (I assume because tests were failing).
It's quite confusing for the final CMS user that you have the option to start a workflow from an active page. Unless I miss something really obvious, I think pages need to be explicitly restored before applying a new workflow.