### PR TITLE
Fix conflict with silverstripe/sharedraftcontent

### DIFF
--- a/src/Extensions/WorkflowApplicable.php
+++ b/src/Extensions/WorkflowApplicable.php
@@ -423,6 +423,11 @@ class WorkflowApplicable extends DataExtension
             return true;
         }
 
+        // Override any default behaviour, to allow the draft link generation
+        if ($this->isShareLinkAction()) {
+            return true;
+        }
+
         if ($active = $this->getWorkflowInstance()) {
             return $active->canEditTarget();
         }
@@ -458,5 +463,20 @@ class WorkflowApplicable extends DataExtension
     public function getWorkflowService()
     {
         return $this->workflowService;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isShareLinkAction()
+    {
+        $shareExtension = ShareDraftContentControllerExtension::class;
+        $currentController = Controller::curr();
+
+        if($currentController->hasExtension($shareExtension) && $currentController->getAction() == 'MakeShareDraftLink') {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Extensions/WorkflowApplicable.php
+++ b/src/Extensions/WorkflowApplicable.php
@@ -21,6 +21,7 @@ use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataList;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\Security;
+use SilverStripe\ShareDraftContent\Extensions\ShareDraftContentControllerExtension;
 use Symbiote\AdvancedWorkflow\DataObjects\WorkflowActionInstance;
 use Symbiote\AdvancedWorkflow\DataObjects\WorkflowDefinition;
 use Symbiote\AdvancedWorkflow\DataObjects\WorkflowInstance;
@@ -470,10 +471,9 @@ class WorkflowApplicable extends DataExtension
      */
     public function isShareLinkAction()
     {
-        $shareExtension = ShareDraftContentControllerExtension::class;
         $currentController = Controller::curr();
 
-        if($currentController->hasExtension($shareExtension) && $currentController->getAction() == 'MakeShareDraftLink') {
+        if ($currentController->hasExtension(ShareDraftContentControllerExtension::class) && $currentController->getAction() == 'MakeShareDraftLink') {
             return true;
         }
 


### PR DESCRIPTION
silverstripe/sharedraftcontent relies on the CanEdit permission in order to understand if a user is allowed to generate a sherable link.

the advancedWorkflow package extends the CanEdit hook returning false for pages in the middle of a workflow when user is not an admin.

As a result, when a user with the right permissions tries to generate a link for a page which needs to be approved, they get an error.

This PR fixes the conflict between the 2 libraries. 