### PR TITLE
Only mark fields as readonly (not form)

### DIFF
--- a/src/Extensions/AdvancedWorkflowExtension.php
+++ b/src/Extensions/AdvancedWorkflowExtension.php
@@ -89,8 +89,8 @@ class AdvancedWorkflowExtension extends Extension
 
             // Set the form to readonly if the current user doesn't have permission to edit the record, and/or it
             // is in a state that requires review
-            if (!$record->canEditWorkflow()) {
-                $form->makeReadonly();
+            if (!$record->canEditWorkflow() && !$fields->isReadonly()) {
+                $fields->makeReadonly();
             }
 
             $this->owner->extend('updateWorkflowEditForm', $form);


### PR DESCRIPTION
Done for performance reasons. CMSMain and LeftAndMain's getEditForm()
perform this readonly transformation on Form->Fields(), not the Form itself.
It's ambiguous if the form is readonly when its fields and actions are readonly.
The easy way out is to simply apply this to the fields instead.
This should also ensure that any actions which *are* still available
for a record with an active approval state (for example "cancel approval request").
See https://github.com/dnadesign/silverstripe-elemental/issues/630
and https://github.com/silverstripe/silverstripe-framework/pull/8853