### PR TITLE
Add test for NotifyUsersWorkflowAction and fix #391

### DIFF
--- a/code/actions/NotifyUsersWorkflowAction.php
+++ b/code/actions/NotifyUsersWorkflowAction.php
@@ -106,7 +106,7 @@ class NotifyUsersWorkflowAction extends WorkflowAction {
 			if($member->Email) {
                 $assigneeVars = $this->getMemberFields($member);
                 if (count($assigneeVars)) {
-                    $item->Assignee = new ArrayData($assigneeVars);
+                    $item->Assignee = $assigneeVars;
                 }
                 
                 $body = $view->process($item);

--- a/tests/WorkflowEngineTest.php
+++ b/tests/WorkflowEngineTest.php
@@ -123,6 +123,60 @@ class WorkflowEngineTest extends SapphireTest {
 		
 	}
 
+    public function testNotifyAction()
+    {
+        $this->logInWithPermission();
+
+        $email = [
+            'Subject' => 'Notification test',
+            'From' => 'notify@test.com'
+        ];
+
+        $action = new NotifyUsersWorkflowAction();
+        $action->EmailSubject = $email['Subject'];
+        $action->EmailFrom = $email['From'];
+
+        $instance = new WorkflowInstance();
+
+        $testUsers = [
+            [
+                'FirstName' => 'Test',
+                'Surname' => 'Test',
+                'Email' => 'test@test.com'
+            ],
+            [
+                'FirstName' => 'Test2',
+                'Surname' => 'Test2',
+                'Email' => 'test2@test.com'
+            ]
+        ];
+
+        foreach ($testUsers as $userData) {
+            $member = new Member($userData);
+            $member->write();
+
+            $instance->Users()->add($member);
+        }
+
+        $page = new SiteTree();
+        $page->Title = 'stuff';
+        $page->write();
+
+        $instance->TargetClass = 'SiteTree';
+        $instance->TargetID = $page->ID;
+        $instance->write();
+
+        $action->execute($instance);
+
+        foreach ($testUsers as $userData) {
+            $this->assertEmailSent(
+                $userData['Email'],
+                $email['From'],
+                $email['Subject']
+            );
+        }
+    }
+
 	public function testCreateDefinitionWithEmptyTitle() {
 		$definition = new WorkflowDefinition();
 		$definition->Title = "";

--- a/tests/WorkflowEngineTest.php
+++ b/tests/WorkflowEngineTest.php
@@ -129,12 +129,14 @@ class WorkflowEngineTest extends SapphireTest {
 
         $email = [
             'Subject' => 'Notification test',
-            'From' => 'notify@test.com'
+            'From' => 'notify@test.com',
+            'Template' => 'Hello $Assignee.FirstName $Assignee.Surname ($Assignee.Email)'
         ];
 
         $action = new NotifyUsersWorkflowAction();
         $action->EmailSubject = $email['Subject'];
         $action->EmailFrom = $email['From'];
+        $action->EmailTemplate = $email['Template'];
 
         $instance = new WorkflowInstance();
 
@@ -169,10 +171,13 @@ class WorkflowEngineTest extends SapphireTest {
         $action->execute($instance);
 
         foreach ($testUsers as $userData) {
-            $this->assertEmailSent(
-                $userData['Email'],
-                $email['From'],
-                $email['Subject']
+            $sentEmail = $this->findEmail($userData['Email'], $email['From'], $email['Subject']);
+
+            $this->assertNotNull($sentEmail);
+
+            $this->assertContains(
+                "Hello ${userData['FirstName']} ${userData['Surname']} (${userData['Email']})",
+                $sentEmail['content']
             );
         }
     }


### PR DESCRIPTION
Setting `$item->Assignee` multiple times was causing a user error (see silverstripe/silverstripe-framework#8883).

The unit test reproduces the error and the change to `NotifyUsersWorkflowAction` fixes it