### PR TITLE
FIX Workflow Actions tab now renders HTML content inside a div instead of a paragraph tag

### DIFF
--- a/src/DataObjects/WorkflowActionInstance.php
+++ b/src/DataObjects/WorkflowActionInstance.php
@@ -69,7 +69,8 @@ class WorkflowActionInstance extends DataObject
                 $field->Title,
                 DBField::create_field('HTMLText', $field->Diff)
             )
-                ->addExtraClass('workflow-field-diff');
+                ->addExtraClass('workflow-field-diff')
+                ->setTemplate(__CLASS__ . '/ReadonlyField');
             $fields->push($display);
         }
 

--- a/templates/Symbiote/AdvancedWorkflow/DataObjects/WorkflowActionInstance/ReadonlyField.ss
+++ b/templates/Symbiote/AdvancedWorkflow/DataObjects/WorkflowActionInstance/ReadonlyField.ss
@@ -1,0 +1,7 @@
+<%-- Modified from silverstripe/admin/themes/cms-forms/templates/SilverStripe/Forms/ReadonlyField.ss to change p to div --%>
+<div id="$ID" tabIndex="0" class="form-control-static<% if $extraClass %> $extraClass<% end_if %>" <% include SilverStripe/Forms/AriaAttributes %>>
+    $Value
+</div>
+<% if $IncludeHiddenField %>
+    <input $getAttributesHTML("id", "type") id="hidden-{$ID}" type="hidden" />
+<% end_if %>


### PR DESCRIPTION
Note that displaying inserted changes when the inserted changes are a new paragraph is still broken.