### PR TITLE
FIX Call FieldList::isReadonly() if it exists otherwise default to existing behaviour

### DIFF
--- a/src/Extensions/AdvancedWorkflowExtension.php
+++ b/src/Extensions/AdvancedWorkflowExtension.php
@@ -89,8 +89,12 @@ class AdvancedWorkflowExtension extends Extension
 
             // Set the form to readonly if the current user doesn't have permission to edit the record, and/or it
             // is in a state that requires review
-            if (!$record->canEditWorkflow() && !$fields->isReadonly()) {
-                $fields->makeReadonly();
+            if (!$record->canEditWorkflow()) {
+                if ($fields->hasMethod('isReadonly') && !$fields->isReadonly()) {
+                    $fields->makeReadonly();
+                } else {
+                    $form->makeReadonly();
+                }
             }
 
             $this->owner->extend('updateWorkflowEditForm', $form);


### PR DESCRIPTION
See https://github.com/symbiote/silverstripe-advancedworkflow/commit/45fcc27e6dbff328a7978e443b7554570233bc07

Fixes https://github.com/symbiote/silverstripe-advancedworkflow/issues/400