### PR TITLE
WorkflowReminderJob missing assigned member emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - php: 5.6
       env: DB=MYSQL RECIPE_VERSION=4.2.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
     - php: 7.0
-      env: DB=PGSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_TEST=1
     - php: 7.1
       env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_COVERAGE_TEST=1
     - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ env:
 matrix:
   include:
     - php: 5.6
-      env: DB=MYSQL RECIPE_VERSION=1.0.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.2.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
     - php: 7.0
-      env: DB=MYSQL RECIPE_VERSION=1.1.x-dev PHPUNIT_TEST=1
+      env: DB=PGSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=MYSQL RECIPE_VERSION=4.2.x-dev PHPUNIT_COVERAGE_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_COVERAGE_TEST=1
     - php: 7.2
-      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.4.x-dev PHPUNIT_TEST=1
     - php: 7.3
       env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
 


### PR DESCRIPTION
Looks like from the upgrade the 'Email' string got replaced with a classname meaning the Bcc column was always empty.