### PR TITLE
Update travis config. Remove <=7.0 php tests and add 7.4 php test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,14 @@ env:
 
 matrix:
   include:
-    - php: 5.6
-      env: DB=MYSQL RECIPE_VERSION=4.2.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
-    - php: 7.0
-      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_TEST=1
     - php: 7.1
       env: DB=MYSQL RECIPE_VERSION=4.4.x-dev PHPUNIT_COVERAGE_TEST=1
     - php: 7.2
-      env: DB=MYSQL RECIPE_VERSION=4.5.x-dev PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.5.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
     - php: 7.3
       env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
+    - php: 7.4
+      env: DB=MYSQL RECIPE_VERSION=4.x-dev PHP_UNIT_TEST=1
 
 before_script:
   - phpenv rehash


### PR DESCRIPTION
This updates the travis config. SS 4.x doesn't support php <7.1 so these tests fail to execute now.

Added php 7.4 test suite