### PR TITLE
Update for 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 
 env:
   global:
-    - COMPOSER_ROOT_VERSION="5.0.x-dev"
+    - COMPOSER_ROOT_VERSION="5.3.x-dev"
 
 matrix:
   include:


### PR DESCRIPTION
composer.json does not need to be updated
```
    "require": {
        "silverstripe/cms": "^4",
        "silverstripe/framework": "^4",
        "silverstripe/admin": "^1",
        "silverstripe/versioned": "^1",
        "symfony/yaml": "~3.2"
    },
```